### PR TITLE
Fix #21: Added environment variable to set custom JWT expiration limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ URL=http://localhost:1337
 # EOS cors domain instance
 EOS_CORS_DOMAINS='https://test-url1.com, https://test-url2.com'
 
+# JWT Expiration duration (set it to values like 1d or 1h)
+# Default value is 1h
+JWT_EXPIRATION=
+
 # DB connection
 # Insert the URI to connect to your database:
 EOS_DATABASE_URI_DEV=

--- a/extensions/users-permissions/config/jwt.js
+++ b/extensions/users-permissions/config/jwt.js
@@ -1,3 +1,6 @@
 module.exports = {
-  jwtSecret: process.env.JWT_SECRET || 'a6336848-f6a7-4553-802c-e05875fc1d50'
+  jwtSecret: process.env.JWT_SECRET || 'a6336848-f6a7-4553-802c-e05875fc1d50',
+  jwt: {
+    expiresIn: process.env.JWT_EXPIRATION || '1h'
+  }
 };


### PR DESCRIPTION
I have added a environment variable `JWT_EXPIRATION` to set the expiration limit for the JWT . 
The default value has been set to 1 hour.

Fixes #21 