### PR TITLE
Fix #23: Added environment variable for Sendgrid

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ EOS_SAMESITE=
 
 # Start strapi with docker
 WITH_DOCKER=true
+
+# API Key to be used by Sendgrid email service
+# Refer https://docs.sendgrid.com/api-reference/api-keys/create-api-keys for getting this API Key
+SENDGRID_API_KEY=

--- a/extensions/email/config/settings.js
+++ b/extensions/email/config/settings.js
@@ -1,7 +1,7 @@
 module.exports = {
     provider: 'sendgrid',
     providerOptions: {
-        apiKey: 'SG.uq6gkZHsSw2v4l4eYrYuPw.phJiQqg_qQKzXj2UggSfJQZ6pBM8LTaI2TYOURPzZ_Q'
+        apiKey: process.env.SENDGRID_API_KEY
     },
     settings: {
       defaultFrom: 'no-reply@eosdesignsystem.com',


### PR DESCRIPTION
I have created an environment variable for Sendgrid email service, named as `SENDGRID_API_KEY`.
I have also added a reference on how to generate this API Key, in the `.env.example` file.

Fixes #23 
