### PR TITLE
Fix #40:Added icon name field in User Story Status collection

### DIFF
--- a/api/user-story-status/documentation/1.0.0/user-story-status.json
+++ b/api/user-story-status/documentation/1.0.0/user-story-status.json
@@ -597,6 +597,9 @@
                 }
               }
             }
+          },
+          "icon_name": {
+            "type": "string"
           }
         }
       },
@@ -613,6 +616,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "icon_name": {
+            "type": "string"
           }
         }
       }

--- a/api/user-story-status/models/user-story-status.settings.json
+++ b/api/user-story-status/models/user-story-status.settings.json
@@ -14,8 +14,11 @@
       "required": true
     },
     "user_stories": {
-      "via": "user_story_status",
-      "collection": "user-story"
+      "collection": "user-story",
+      "via": "user_story_status"
+    },
+    "icon_name": {
+      "type": "string"
     }
   }
 }

--- a/api/user-story/documentation/1.0.0/user-story.json
+++ b/api/user-story/documentation/1.0.0/user-story.json
@@ -721,6 +721,9 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "icon_name": {
+                "type": "string"
               }
             }
           },

--- a/api/user-story/models/user-story.settings.json
+++ b/api/user-story/models/user-story.settings.json
@@ -47,8 +47,8 @@
       "via": "user_stories"
     },
     "user_story_status": {
-      "model": "user-story-status",
-      "via": "user_stories"
+      "via": "user_stories",
+      "model": "user-story-status"
     },
     "user_story_comments": {
       "via": "user_story",

--- a/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "10/06/2022 8:34:23 PM"
+    "x-generation-date": "10/10/2022 4:09:00 PM"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -8828,6 +8828,9 @@
                 }
               }
             }
+          },
+          "icon_name": {
+            "type": "string"
           }
         }
       },
@@ -8844,6 +8847,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "icon_name": {
+            "type": "string"
           }
         }
       },
@@ -9041,6 +9047,9 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "icon_name": {
+                "type": "string"
               }
             }
           },


### PR DESCRIPTION
**Issue Number**

fixes #40 

<!-- Please Mention the issue number as ISSUE #(Issue Number)
Example:
fixes #1
-->

**Describe the changes you've made**

I have added `icon_name` as a field in the **User Story Status** collection. This will store the name of the icon corresponding to each status type.


**Additional context (OPTIONAL)**

NA


**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

**Provide a Deployed link of route/page that needs to review**


![image](https://user-images.githubusercontent.com/75155230/194849804-7ccf2db2-0b40-4db2-bb72-cb6309457811.png)

![image](https://user-images.githubusercontent.com/75155230/194849898-792a9e9f-fee5-4210-8e79-bd29e15a42cd.png)

